### PR TITLE
Fix/tratamento duplicados

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ class Main:
 
 	def run(self):
 		os.makedirs("data", exist_ok=True)
+		os.makedirs("database", exist_ok=True)
+		open('./database/modelos.txt', 'a').close()
 		subprocess.run(["streamlit", "run", "app.py"])
 
 if __name__ == "__main__":

--- a/pages/home.py
+++ b/pages/home.py
@@ -24,27 +24,28 @@ with st.sidebar:
 		modelos = f.read().splitlines()
 	modelo = st.selectbox('Modelo', modelos, index=0, help='Escolha o modelo a ser utilizado. O modelo deepseek-r1-distill-qwen-32b é o mais avançado e pode fornecer melhores resultados, mas também é mais pesado e pode levar mais tempo para gerar respostas.')
 	temperatura = st.slider(label='Temperatura', min_value=0.0, max_value=1.0, value=0.7, step=0.1, help='A temperatura controla a aleatoriedade da resposta do modelo. Valores mais altos resultam em respostas mais criativas e variados.')
-	st.write('---')
-	st.write(f"#### ⚙️ Configurações do Prompt - {dataset}")
-		
-	
-	df = pd.read_csv(f'data/{dataset}')
-	data_min = pd.to_datetime(df['date']).min().date()
-	data_max = pd.to_datetime(df['date']).max().date()
 
-	valor_default_inicio = data_min
-	valor_default_fim = min(data_min + pd.Timedelta(days=1), data_max)
+	if dataset is not None:
+		st.write('---')
+		st.write(f"#### ⚙️ Configurações do Prompt - {dataset}")
 
-	data_inicio = st.date_input(label='Data de início', max_value=data_max, min_value=data_min, value=valor_default_inicio)
-	data_fim = st.date_input(label='Data de término', max_value=data_max, min_value=data_min, value=valor_default_fim)
-		
-	periodos = st.slider(label='Períodos', min_value=24, max_value=96, value=24, step=1, help='Número de períodos a serem previstos. Cada período representa 1 hora de previsão.')
-	tipo_prompt = st.radio(label='Prompt', options=['ZERO_SHOT', 'FEW_SHOT', 'COT', 'COT_FEW'], index=0, help='Escolha o tipo de prompt a ser utilizado')
-	tipo_serie = st.radio(label='Tipo de Série', options=['Numérica', 'Textual'], index=0, help='Escolha o tipo de série temporal. A série numérica os valores são passados como números, enquanto a série textual os valores são passados como texto. A série textual pode ser mais lenta para gerar respostas, mas pode fornecer resultados mais precisos em alguns casos.')
+		df = pd.read_csv(f'data/{dataset}')
+		data_min = pd.to_datetime(df['date']).min().date()
+		data_max = pd.to_datetime(df['date']).max().date()
 
-	confirma = st.button(label='Gerar Análise', key='gerar_analise', help='Clique para gerar a análise de dados',type='primary', use_container_width=True)
+		valor_default_inicio = data_min
+		valor_default_fim = min(data_min + pd.Timedelta(days=1), data_max)
 
-if confirma:
+		data_inicio = st.date_input(label='Data de início', max_value=data_max, min_value=data_min, value=valor_default_inicio)
+		data_fim = st.date_input(label='Data de término', max_value=data_max, min_value=data_min, value=valor_default_fim)
+
+		periodos = st.slider(label='Períodos', min_value=24, max_value=96, value=24, step=1, help='Número de períodos a serem previstos. Cada período representa 1 hora de previsão.')
+		tipo_prompt = st.radio(label='Prompt', options=['ZERO_SHOT', 'FEW_SHOT', 'COT', 'COT_FEW'], index=0, help='Escolha o tipo de prompt a ser utilizado')
+		tipo_serie = st.radio(label='Tipo de Série', options=['Numérica', 'Textual'], index=0, help='Escolha o tipo de série temporal. A série numérica os valores são passados como números, enquanto a série textual os valores são passados como texto. A série textual pode ser mais lenta para gerar respostas, mas pode fornecer resultados mais precisos em alguns casos.')
+
+		confirma = st.button(label='Gerar Análise', key='gerar_analise', help='Clique para gerar a análise de dados',type='primary', use_container_width=True)
+
+if dataset and confirma:
 	Header(dataset=dataset, data_fim=str(data_fim), data_inicio=str(data_inicio), modelo=modelo, periodos=periodos, tipo_prompt=tipo_prompt, tipo_serie=tipo_serie).header()
 	Dataset(dataset=dataset, data_inicio=str(data_inicio), data_fim=str(data_fim), qtd_periodos=periodos).exibir_dados()
 	prompt, lista_exato = Prompt(dataset=dataset, data_inicio=str(data_inicio), data_fim=str(data_fim), qtd_periodos=periodos, tipo_prompt=tipo_prompt, tipo_serie=tipo_serie).prompt()
@@ -52,20 +53,20 @@ if confirma:
 	smape, mae, rmse = Resultados(val_exatos=lista_exato, val_previstos=resposta, qtd_tokens_prompt=qtd_tokens_prompt, qtd_tokens_resposta=qtd_tokens_predito, tempo=tempo).exibir_resultados()
 
 	confirme_insert = Crud().insert(
-		data_inicio=data_inicio, 
-		data_fim=data_fim, 
+		data_inicio=data_inicio,
+		data_fim=data_fim,
 		periodos=periodos,
 		modelo=modelo,
 		temperatura_modelo=temperatura,
 		prompt=prompt,
-		tipo_prompt=tipo_prompt, 
-		valores_exatos=str(lista_exato), 
-		valores_previstos=str(resposta), 
-		smape=smape, 
+		tipo_prompt=tipo_prompt,
+		valores_exatos=str(lista_exato),
+		valores_previstos=str(resposta),
+		smape=smape,
 		mae=mae,
 		rmse=rmse,
-		total_tokens_resposta=qtd_tokens_predito, 
-		total_tokens_prompt=qtd_tokens_prompt, 
+		total_tokens_resposta=qtd_tokens_predito,
+		total_tokens_prompt=qtd_tokens_prompt,
 		total_tokens=qtd_tokens_predito+qtd_tokens_prompt,
 		base_dados= dataset
 	)

--- a/pages/upload.py
+++ b/pages/upload.py
@@ -44,7 +44,7 @@ def configuracao_dataset(dataset, uploaded_file):
 		elif tratamento == "Manter o último":
 			df = df.drop_duplicates(subset="date", keep="last")
 		elif tratamento == "Somar valores duplicados":
-			df = df.groupby("date", as_index=False)['value'].transform('sum')
+			df = df.groupby("date", as_index=False)['value'].sum()
 
 		# Salvar
 		file_path = f"data/{uploaded_file.name}"


### PR DESCRIPTION
# Correção no tratamento de valores duplicados

Ajusta o tratamento para usar `groupby().sum()` ao invés de `transform('sum')`, garantindo que o DataFrame resultante mantenha a coluna `date`.

![Captura de tela de 2025-07-09 10-45-53](https://github.com/user-attachments/assets/8e8fa0b1-6823-4ccb-ac77-e89bf298b24e)
(Erro exibido para o usuário.)

![Captura de tela de 2025-07-09 10-46-14](https://github.com/user-attachments/assets/335e1aeb-8f16-4671-8765-f2aab12cf7b0)
(CSV com apenas a coluna `value` e sem a coluna `date`, causando o erro esperado.)

## Antes
```python
# pages/upload.py
elif tratamento == "Somar valores duplicados":
	df = df.groupby("date", as_index=False)['value'].transform('sum')
```

## Depois
```python
# pages/upload.py
elif tratamento == "Somar valores duplicados":
	df = df.groupby("date", as_index=False)['value'].sum()
```